### PR TITLE
Fix Surface destruction with a NULL Handle

### DIFF
--- a/include/vku/vku_framework.hpp
+++ b/include/vku/vku_framework.hpp
@@ -291,7 +291,7 @@ public:
   }
 
   void init(const vk::Instance &instance, const vk::Device &device, const vk::PhysicalDevice &physicalDevice, uint32_t graphicsQueueFamilyIndex, vk::SurfaceKHR surface) {
-    surface_ = vk::UniqueSurfaceKHR(surface);
+    surface_ = vk::UniqueSurfaceKHR(surface, vk::SurfaceKHRDeleter{ instance });
     device_ = device;
     presentQueueFamily_ = 0;
     auto &pd = physicalDevice;


### PR DESCRIPTION
UniqueSurface uses a default SurfaceDeleter which destroys the given surface on
a NULL instance HANDLE.
Therefore, the surface is not correctly destroyed on window destruction which can lead to a memory leak
or an exception/program crash.